### PR TITLE
Fix institute option typo

### DIFF
--- a/src/app/register/page.jsx
+++ b/src/app/register/page.jsx
@@ -191,7 +191,7 @@ const Form = () => {
                             >
                                 <option value="male">ذكَر</option>
                                 <option value="female">أنثى</option>
-                                <option value="inistitute">مؤسسة</option>
+                                <option value="institute">مؤسسة</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- fix typo for the institute option on the register page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f14ea369c8326a801eb3222eb172d